### PR TITLE
Se añade la prueba unitaria para la función ExtractOnlyLetter, en la …

### DIFF
--- a/src/tests/unit/test_only_letter.py
+++ b/src/tests/unit/test_only_letter.py
@@ -1,0 +1,20 @@
+from sre_constants import CATEGORY_UNI_LINEBREAK
+import pandas as pd
+import numpy as np
+import re
+import pytest
+
+def ExtractOnlyLetter(x):
+    if type(x)==str:    
+        return ''.join(re.findall("[a-zA-Z]+", x))  
+    return x
+
+def ExtractOnlyLetterResult():
+    return [(pd.DataFrame(['A1','B1','C1','CC2','$D1',np.nan], columns=['cabin']),
+    pd.DataFrame(['A','B','C','CC','D',np.nan], columns=['cabin']) )]
+
+
+@pytest.mark.parametrize("df, result", ExtractOnlyLetterResult())
+def test_extract_only_letter(df,result):
+    test_result = df['cabin'].apply(ExtractOnlyLetter).to_frame()
+    assert test_result.equals(result)


### PR DESCRIPTION
Se añadió la prueba unitaria para la función de extraer la palabra de una columna en un dataframe, lo unico que se debe cambiar es la función 
def ExtractOnlyLetter(x):
    if type(x)==str:    
        return ''.join(re.findall("[a-zA-Z]+", x))  
    return x
Por la función en forma de transformer.

Así mismo se añade la carpeta test/unit a /src