### PR TITLE
MedianImputation_RareLabel_TestMinMax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,9 @@ coverage
 awscli
 flake8
 python-dotenv>=0.5.1
+
+numpy~=1.21.6
+pandas~=1.3.5
+scikit-learn~=1.0.2
+setuptools~=47.1.0
+pytest~=7.1.1

--- a/src/features/median_imputation.py
+++ b/src/features/median_imputation.py
@@ -1,0 +1,19 @@
+from sklearn.base import BaseEstimator, TransformerMixin
+from typing import List
+import pandas as pd
+
+
+class NumericalImputesEncoder(BaseEstimator, TransformerMixin):
+    def __init__(self, variables: List[str] = None):
+        self.variables = variables
+        self.valid_labels_dict = {}
+
+    def fit(self, data_df: pd.DataFrame):
+        for var in self.variables:
+            t = data_df[var].median()
+            self.valid_labels_dict[var] = t
+
+    def transform(self, data_df: pd.DataFrame):
+        for var in self.variables:
+            data_df[var] = data_df[var].fillna(self.valid_labels_dict[var])
+        return data_df

--- a/src/features/min_max_scaler.py
+++ b/src/features/min_max_scaler.py
@@ -7,9 +7,9 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
     def __init__(self):
         self.scaler = MMScaler()
 
-    def fit(self, X:pd.DataFrame) -> None:
+    def fit(self, X:pd.DataFrame):
         self.scaler.fit(X)
 
-    def transform(self, X:pd.DataFrame) -> None:
+    def transform(self, X:pd.DataFrame):
         X_scaled = self.scaler.transform(X)
         return X_scaled

--- a/src/features/rare_label_categorial.py
+++ b/src/features/rare_label_categorial.py
@@ -1,0 +1,21 @@
+from sklearn.base import BaseEstimator, TransformerMixin
+from typing import List
+import pandas as pd
+
+
+class RareLabelCategoricalEncoder(BaseEstimator, TransformerMixin):
+    def __init__(self, tol=0.02, variables: List[str] = None):
+        self.tol = tol
+        self.variables = variables
+        self.valid_labels_dict = {}
+
+    def fit(self, dat_df: pd.DataFrame):
+        for var in self.variables:
+            t = dat_df[var].value_counts() / dat_df.shape[0]
+            self.valid_labels_dict[var] = t[t > self.tol].index.tolist()
+
+    def transform(self, data_df: pd.DataFrame):
+        for var in self.variables:
+            tmp = [col for col in data_df[var].unique() if col not in self.valid_labels_dict[var]]
+            data_df[var] = data_df[var].replace(to_replace=tmp, value=len(tmp) * ['Rare'])
+        return data_df

--- a/src/tests/unit/test_minmax_scaler.py
+++ b/src/tests/unit/test_minmax_scaler.py
@@ -1,0 +1,18 @@
+import pytest
+import pandas as pd
+from src.features.min_max_scaler import MinMaxScaler
+import numpy as np
+
+
+def GetMinMaxScaleTestData():
+    df = pd.DataFrame([[1,1],[2,0],[3,1],[4,0],[5,1]], columns =['a','b'])
+    result = pd.DataFrame([[0,1.0],[0.25,0.0],[0.5,1.0],[0.75,0.0],[1,1.0]], columns=['a','b'])
+    return [(df, result)]
+
+
+@pytest.mark.parametrize("df, result", GetMinMaxScaleTestData())
+def test_extract_only_letter(df, result):
+    minmax_scaler = MinMaxScaler()
+    minmax_scaler.fit(df)
+    test_result = minmax_scaler.transform(df)
+    assert pd.DataFrame(test_result, columns=['a', 'b']).equals(result)

--- a/src/tests/unit/test_rare_label.py
+++ b/src/tests/unit/test_rare_label.py
@@ -1,25 +1,6 @@
 import pytest
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
-from typing import List
-
-
-class RareLabelCategoricalEncoder(BaseEstimator, TransformerMixin):
-    def __init__(self, tol=0.02, variables: List[str] = None):
-        self.tol =tol
-        self.variables = variables
-    
-    def fit(self, X: pd.DataFrame):
-        self.valid_labels_dict = {}
-        for var in self.variables:
-            t = X[var].value_counts() / X.shape[0]
-            self.valid_labels_dict[var] = t[t>self.tol].index.tolist()
-
-    def transform(self, X:pd.DataFrame):
-        for var in self.variables:
-            tmp = [col for col in X[var].unique() if col not in self.valid_labels_dict[var]]
-            X[var] = X[var].replace(to_replace=tmp, value=len(tmp) * ['Rare'])
-        return X
+from src.features.rare_label_categorial import RareLabelCategoricalEncoder
 
 
 def GetRareLabelTestData():
@@ -27,15 +8,11 @@ def GetRareLabelTestData():
     result = pd.read_csv('rare_labels_csv_result')
     return [(df, result)]
 
+
 @pytest.mark.parametrize("df, result", GetRareLabelTestData())
-def test_extract_only_letter(df,result):
-    print(df)
+def test_extract_only_letter(df, result):
     cat_vars = ['sex', 'cabin', 'embarked', 'title']
     rare_labels = RareLabelCategoricalEncoder(tol=0.02, variables=cat_vars)
     rare_labels.fit(df)
     test_result = rare_labels.transform(df)
     assert test_result.equals(result)
-
-
-
-


### PR DESCRIPTION
Se crea la rama MedianImputationAndRareLabel que contiene los script para los métodos de median_imputation y rare_label_categorical, también se agrega la prueba unitaria para la función min_max_scaler.